### PR TITLE
Throw result when is an instance of Error

### DIFF
--- a/lib/mongo-sync.js
+++ b/lib/mongo-sync.js
@@ -23,7 +23,7 @@ function sync(obj, fn) {
       Fiber.yield();
     }
     if (result instanceof Error) {
-      throw new Error(result.stack + '\nFollowed by:');
+      throw result;
     }
     return result;
   };


### PR DESCRIPTION
I think throwing the error as it is lets the user handle it in a better way.
