### PR TITLE
add server.connect method that accept Mongo URI

### DIFF
--- a/lib/mongo-sync.js
+++ b/lib/mongo-sync.js
@@ -48,15 +48,27 @@ Server.prototype.db = function(name) {
   return new DB(this, name);
 };
 
+Server.prototype.connect = function(uri) {
+  return new DB(this, null, uri);
+};
+
 Server.prototype.close = function() {
   this._server.close();
 };
 
-function DB(server, name) {
+function DB(server, name, uri) {
   this._server = server;
   this._name = name;
-  this._db = new mongodb.Db(name, server._server, {w:1});
-  sync('_db', 'open').call(this);
+  // TODO: reimplement this the proper way
+  if (uri) {
+    this._db = mongodb.Db;
+    this._db = sync('_db', 'connect').call(this, uri);
+  } else {
+    this._db = new mongodb.Db(name, server._server, {
+      w: 1
+    });
+    sync('_db', 'open').call(this);
+  }
 }
 
 exports.DB = DB;


### PR DESCRIPTION
These changes is demonstration. According to http://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html `mongo-sync` needs API to be able to connect to Mongo servers / clusters using connection string. 

Implemented API proporsal is excessive:

```
var db = new mongo.Server(host, port).connect(MONGO_URI);
      app.db = server.;
```

Please, consider to add this or something related.
